### PR TITLE
[Ania-10]  Fix pagination system for /archive command

### DIFF
--- a/src/SlashCommands/students/src/archive/archiveLab.ts
+++ b/src/SlashCommands/students/src/archive/archiveLab.ts
@@ -11,7 +11,7 @@ import { readdirSync } from 'fs';
 import drawArchiveCanvas from '../canvas/drawingCanvas';
 import data from '../../../../assets/json/promos.json';
 import { translator } from './translator';
-import { numbers, userPages } from './userPages';
+import { numbers } from './userPages';
 
 const getTps = async (ressource: string): Promise<string[]> => {
     const fields = [];
@@ -46,7 +46,8 @@ const getTps = async (ressource: string): Promise<string[]> => {
 
 const drawTpCanvas = async (
     interaction: ButtonInteraction<CacheType>,
-    ressource: string
+    ressource: string,
+    currentPage: number = 0
 ) => {
     const row = new ActionRowBuilder<ButtonBuilder>();
     const row2 = new ActionRowBuilder<ButtonBuilder>();
@@ -60,14 +61,7 @@ const drawTpCanvas = async (
         return { buffer: null, row: null };
     }
     const totalPages = Math.ceil(translatedTopics.length / 8);
-    if (!userPages.has(interaction.user.id)) {
-        userPages.set(interaction.user.id, { currentPage: 0, totalPages });
-    } else {
-        const userPage = userPages.get(interaction.user.id);
-        userPages.set(interaction.user.id, { ...userPage, totalPages });
-    }
 
-    const { currentPage } = userPages.get(interaction.user.id);
     const currentTopics = translatedTopics.slice(
         currentPage * 8,
         (currentPage + 1) * 8
@@ -125,7 +119,7 @@ const drawTpCanvas = async (
         if (currentPage > 0) {
             row.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_topic-previous')
+                    .setCustomId(`_topic-previous-${currentPage}`)
                     .setLabel('👈')
                     .setStyle(2)
             );
@@ -134,7 +128,7 @@ const drawTpCanvas = async (
         if (currentPage < totalPages - 1) {
             row2.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_topic-next')
+                    .setCustomId(`_topic-next-${currentPage}`)
                     .setLabel('👉')
                     .setStyle(2)
             );

--- a/src/SlashCommands/students/src/archive/archiveMp.ts
+++ b/src/SlashCommands/students/src/archive/archiveMp.ts
@@ -11,7 +11,7 @@ import drawArchiveCanvas from '../canvas/drawingCanvas';
 import { ButtonInteraction } from 'discord.js';
 import data from '../../../../assets/json/promos.json';
 import { translator } from './translator';
-import { numbers, userPages } from './userPages';
+import { numbers } from './userPages';
 
 const getMps = async (ressource: string): Promise<string[]> => {
     const fields = [];
@@ -47,7 +47,8 @@ const getMps = async (ressource: string): Promise<string[]> => {
 
 const drawMpCanvas = async (
     interaction: ButtonInteraction<CacheType>,
-    ressource: string
+    ressource: string,
+    currentPage: number = 0
 ) => {
     const row = new ActionRowBuilder<ButtonBuilder>();
     const row2 = new ActionRowBuilder<ButtonBuilder>();
@@ -63,14 +64,6 @@ const drawMpCanvas = async (
 
     const totalPages = Math.ceil(translatedTopics.length / 8);
 
-    if (!userPages.has(interaction.user.id)) {
-        userPages.set(interaction.user.id, { currentPage: 0, totalPages });
-    } else {
-        const userPage = userPages.get(interaction.user.id);
-        userPages.set(interaction.user.id, { ...userPage, totalPages });
-    }
-
-    const { currentPage } = userPages.get(interaction.user.id);
     const currentTopics = translatedTopics.slice(
         currentPage * 8,
         (currentPage + 1) * 8
@@ -131,7 +124,7 @@ const drawMpCanvas = async (
         if (currentPage > 0) {
             row.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_mp-previous')
+                    .setCustomId(`_mp-previous-${currentPage}`)
                     .setLabel('👈')
                     .setStyle(2)
             );
@@ -140,7 +133,7 @@ const drawMpCanvas = async (
         if (currentPage < totalPages - 1) {
             row2.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_mp-next')
+                    .setCustomId(`_mp-next-${currentPage}`)
                     .setLabel('👉')
                     .setStyle(2)
             );

--- a/src/SlashCommands/students/src/archive/archiveSheet.ts
+++ b/src/SlashCommands/students/src/archive/archiveSheet.ts
@@ -11,7 +11,7 @@ import drawArchiveCanvas from '../canvas/drawingCanvas';
 import { ButtonInteraction } from 'discord.js';
 import data from '../../../../assets/json/promos.json';
 import { translator } from './translator';
-import { numbers, userPages } from './userPages';
+import { numbers } from './userPages';
 
 const getFiches = async (ressource: string): Promise<string[]> => {
     const fields: string[] = [];
@@ -47,7 +47,8 @@ const getFiches = async (ressource: string): Promise<string[]> => {
 
 const drawFicheCanvas = async (
     interaction: ButtonInteraction<CacheType>,
-    ressource: string
+    ressource: string,
+    currentPage: number = 0
 ) => {
     const row = new ActionRowBuilder<ButtonBuilder>();
     const row2 = new ActionRowBuilder<ButtonBuilder>();
@@ -68,14 +69,6 @@ const drawFicheCanvas = async (
 
     const totalPages = Math.ceil(translatedTopics.length / 8);
 
-    if (!userPages.has(interaction.user.id)) {
-        userPages.set(interaction.user.id, { currentPage: 0, totalPages });
-    } else {
-        const userPage = userPages.get(interaction.user.id);
-        userPages.set(interaction.user.id, { ...userPage, totalPages });
-    }
-
-    const { currentPage } = userPages.get(interaction.user.id);
     const currentTopics = translatedTopics.slice(
         currentPage * 8,
         (currentPage + 1) * 8
@@ -131,7 +124,7 @@ const drawFicheCanvas = async (
         if (currentPage > 0) {
             row.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_sheet-previous')
+                    .setCustomId(`_sheet-previous-${currentPage}`)
                     .setLabel('👈')
                     .setStyle(2)
             );
@@ -140,7 +133,7 @@ const drawFicheCanvas = async (
         if (currentPage < totalPages - 1) {
             row2.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('_sheet-next')
+                    .setCustomId(`_sheet-next-${currentPage}`)
                     .setLabel('👉')
                     .setStyle(2)
             );

--- a/src/SlashCommands/students/src/archive/archiveTopics.ts
+++ b/src/SlashCommands/students/src/archive/archiveTopics.ts
@@ -11,7 +11,7 @@ import drawArchiveCanvas from '../canvas/drawingCanvas';
 import { ButtonInteraction } from 'discord.js';
 import data from '../../../../assets/json/promos.json';
 import { translator } from './translator';
-import { numbers, userPages } from './userPages';
+import { numbers } from './userPages';
 
 const getTopics = async (
     category: string,
@@ -96,7 +96,8 @@ const drawTopicsCanvas = async (
     interaction: ButtonInteraction<CacheType>,
     title: string,
     field: string,
-    ressource: string
+    ressource: string,
+    currentPage: number = 0
 ) => {
     const category: string = field.split('-')[1];
     const topicName: string = field.split('-')[0];
@@ -114,15 +115,7 @@ const drawTopicsCanvas = async (
     }
 
     const totalPages = Math.ceil(translatedTopics.length / 8);
-    console.log(interaction.user.id);
-    if (!userPages.has(interaction.user.id)) {
-        userPages.set(interaction.user.id, { currentPage: 0, totalPages });
-    } else {
-        const userPage = userPages.get(interaction.user.id);
-        userPages.set(interaction.user.id, { ...userPage, totalPages });
-    }
 
-    const { currentPage } = userPages.get(interaction.user.id);
     const currentTopics = translatedTopics.slice(
         currentPage * 8,
         (currentPage + 1) * 8
@@ -188,7 +181,9 @@ const drawTopicsCanvas = async (
         if (currentPage > 0) {
             row.addComponents(
                 new ButtonBuilder()
-                    .setCustomId(`${topicName}-${category}_topic-previous`)
+                    .setCustomId(
+                        `${topicName}-${category}_topic-previous-${currentPage}`
+                    )
                     .setLabel('👈')
                     .setStyle(2)
             );
@@ -197,7 +192,9 @@ const drawTopicsCanvas = async (
         if (currentPage < totalPages - 1) {
             row2.addComponents(
                 new ButtonBuilder()
-                    .setCustomId(`${topicName}-${category}_topic-next`)
+                    .setCustomId(
+                        `${topicName}-${category}_topic-next-${currentPage}`
+                    )
                     .setLabel('👉')
                     .setStyle(2)
             );

--- a/src/SlashCommands/students/src/archive/userPages.ts
+++ b/src/SlashCommands/students/src/archive/userPages.ts
@@ -1,10 +1,5 @@
-import { ButtonInteraction, CacheType } from 'discord.js';
-
 // userPages.ts
-const userPages = new Map<
-    string,
-    { currentPage: number; totalPages: number }
->();
+import { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
 
 const numbers = [
     '1189297626529660968',
@@ -18,35 +13,19 @@ const numbers = [
 ];
 
 const sendNewPage = async (
-    interaction: ButtonInteraction<CacheType>,
-    buffer,
-    row,
-    row2
-) => {
-    const components = [];
-    components.push(row);
-
-    console.log(row2);
-
-    if (row2 !== null && row2 !== undefined) {
-        if (row2.components.length > 0) {
-            components.push(row2);
-        }
-    }
-
+    interaction: ButtonInteraction,
+    buffer: Buffer,
+    row: ActionRowBuilder<ButtonBuilder>,
+    row2: ActionRowBuilder<ButtonBuilder>
+): Promise<void> => {
+    // Now, send or update the interaction and filter any empty rows
+    const components = [row, row2].filter((r) => r.components.length > 0);
     try {
-        await interaction.update({
-            content: '',
-            files: [buffer],
-            components: components,
-        });
-    } catch (e) {
-        await interaction.reply({
-            content: '',
-            files: [buffer],
-            components: components,
-        });
+        await interaction.update({ content: '', files: [buffer], components });
+    } catch (error) {
+        console.error('Error updating the interaction:', error);
+        // Handle the error appropriately
     }
 };
 
-export { userPages, numbers, sendNewPage };
+export { numbers, sendNewPage };

--- a/src/events/guild/interactionCreate.ts
+++ b/src/events/guild/interactionCreate.ts
@@ -31,10 +31,7 @@ import {
     StringSelectMenuInteraction,
     TextChannel,
 } from 'discord.js';
-import {
-    sendNewPage,
-    userPages,
-} from '../../SlashCommands/students/src/archive/userPages';
+import { sendNewPage } from '../../SlashCommands/students/src/archive/userPages';
 
 export default new Event('interactionCreate', async (interaction) => {
     if (!interaction.inGuild()) {
@@ -88,7 +85,6 @@ export default new Event('interactionCreate', async (interaction) => {
 
     if (interaction.isButton()) {
         const button = interaction as ButtonInteraction;
-        const userId = button.user.id;
 
         // ===============
         // IPSA EMAIL SYSTEM
@@ -237,32 +233,19 @@ export default new Event('interactionCreate', async (interaction) => {
         }
 
         if (
-            button.customId.endsWith('-previous') ||
-            button.customId.endsWith('-next')
+            button.customId.includes('-previous') ||
+            button.customId.includes('-next')
         ) {
-            if (!userPages.has(userId)) {
-                userPages.set(userId, {
-                    currentPage: 0,
-                    totalPages: 0,
-                });
-            }
-            const { currentPage, totalPages } = userPages.get(userId);
+            // get number of page it's after the last "-"
+            const currentPage = Number(button.customId.split('-').pop());
+            // get if the string contains "previous" or "next" regex
+            const action = button.customId.match(/previous|next/)[0];
 
-            //  reduce the current page by one if the button is previous
-            if (button.customId.endsWith('-previous')) {
-                userPages.set(interaction.user.id, {
-                    currentPage: currentPage - 1,
-                    totalPages,
-                });
-            }
+            const newPage: number =
+                action === 'previous' ? currentPage - 1 : currentPage + 1;
 
-            // increase the current page by one if the button is next
-            if (button.customId.endsWith('-next')) {
-                userPages.set(interaction.user.id, {
-                    currentPage: currentPage + 1,
-                    totalPages,
-                });
-            }
+            console.log('newPage: ' + newPage);
+            console.log(action);
 
             // Redraw the buttons
             let ressource: string;
@@ -281,7 +264,8 @@ export default new Event('interactionCreate', async (interaction) => {
                     interaction,
                     'Les modules',
                     field,
-                    ressource
+                    ressource,
+                    newPage
                 );
                 console.log('row: ' + row);
                 await sendNewPage(button, buffer, row, row2);
@@ -290,7 +274,8 @@ export default new Event('interactionCreate', async (interaction) => {
             if (topic === 'sheet') {
                 const { buffer, row, row2 } = await drawFicheCanvas(
                     interaction,
-                    ressource
+                    ressource,
+                    newPage
                 );
                 await sendNewPage(button, buffer, row, row2);
             }
@@ -298,7 +283,8 @@ export default new Event('interactionCreate', async (interaction) => {
             if (topic === 'mp') {
                 const { buffer, row, row2 } = await drawMpCanvas(
                     interaction,
-                    ressource
+                    ressource,
+                    newPage
                 );
                 await sendNewPage(button, buffer, row, row2);
             }
@@ -306,7 +292,8 @@ export default new Event('interactionCreate', async (interaction) => {
             if (topic === 'lab') {
                 const { buffer, row, row2 } = await drawTpCanvas(
                     interaction,
-                    ressource
+                    ressource,
+                    newPage
                 );
                 await sendNewPage(button, buffer, row, row2);
             }


### PR DESCRIPTION
This pull request addresses an issue with the pagination system for the /archive command in our Discord bot. Previously, the state of the pagination (i.e., the current page) was shared across all users. This meant that if one user clicked the "next" button, the current page would be updated for all users, not just the one who clicked the button.

This issue resulted in massive crash accross all users because of the row component body limitation.